### PR TITLE
[FIX] account-invoicing: isolate multi-company behavior

### DIFF
--- a/account_background_post/__manifest__.py
+++ b/account_background_post/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Background Post",
-    "version": "19.0.1.8.0",
+    "version": "19.0.1.8.1",
     "author": "ADHOC SA",
     "depends": [
         "account",

--- a/account_background_post/models/account_move.py
+++ b/account_background_post/models/account_move.py
@@ -22,11 +22,21 @@ class AccountMove(models.Model):
 
     @api.model
     def _cron_background_post_invoices(self, ids=None):
-        """Busca las facturas que estan marcadas por ser validadas en background y las valida."""
+        """Post invoices queued for background processing."""
         if ids is not None:
             moves = self.browse(ids)
         else:
-            moves = self.search([("background_post", "=", True), ("state", "=", "draft")])
+            moves = self.search(
+                [
+                    ("background_post", "=", True),
+                    ("state", "=", "draft"),
+                    ("country_code", "=", "AR"),
+                    ("move_type", "in", ("out_invoice", "out_refund")),
+                ]
+            )
+        moves = moves.filtered(
+            lambda move: move.country_code == "AR" and move.move_type in ("out_invoice", "out_refund")
+        )
 
         total_len = len(moves)
         self.env["ir.cron"]._commit_progress(remaining=total_len)
@@ -49,22 +59,12 @@ class AccountMove(models.Model):
                 self.env.cr.commit()  # pylint: disable=invalid-commit
 
     def _post(self, soft=True):
-        """Difiere el posteo de documentos de venta (facturas y notas de crédito) a background,
-        para no bloquear el flujo sincrónico por validaciones externas lentas (ej. ARCA).
-
-        Si el contexto trae `force_background_post`, saltea el `super()._post()` para facturas
-        de cliente y notas de crédito/débito de venta (`out_invoice`, `out_refund`); el resto
-        de los moves postea normalmente."""
         to_defer = self.env["account.move"]
         if self.env.context.get("force_background_post"):
-            to_defer = self.filtered(lambda m: m.move_type in ("out_invoice", "out_refund"))
-            to_defer.write({"background_post": True})
+            to_defer = self.filtered(
+                lambda move: move.country_code == "AR" and move.move_type in ("out_invoice", "out_refund")
+            )
+            to_defer.background_post = True
         posted = super(AccountMove, self - to_defer)._post(soft=soft)
         posted.filtered("background_post").background_post = False
         return posted
-
-    def _get_moves_requiring_confirmation(self):
-        """Override method to always open the confirmation wizard
-        when trying to set a background_post invoice.
-        """
-        return self

--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -62,7 +62,6 @@ class ValidateAccountMove(models.TransientModel):
         for move in background_moves:
             _logger.info("Validating invoice %s", move.id)
             move.action_post()
-            move.env.cr.commit()
         return {"type": "ir.actions.act_window_close"}
 
     def validate_move_confirm(self):

--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -12,55 +12,58 @@ class ValidateAccountMove(models.TransientModel):
     count_inv = fields.Integer(help="Technical field to know the number of invoices selected from the wizard")
     batch_size = fields.Integer(compute="_compute_batch_size")
     force_background = fields.Integer(compute="_compute_force_background")
+    use_background_post = fields.Boolean(compute="_compute_use_background_post")
 
     def _compute_batch_size(self):
-        self.batch_size = self.env["ir.config_parameter"].sudo().get_param("account_background_post.batch_size", 20)
+        self.batch_size = int(self.env["ir.config_parameter"].sudo().get_param("account_background_post.batch_size", 20))
 
     def _compute_force_background(self):
         for rec in self:
             rec.force_background = rec.count_inv > rec.batch_size
 
+    def _compute_use_background_post(self):
+        for rec in self:
+            rec.use_background_post = bool(rec.move_ids) and all(
+                move.country_code == "AR" and move.move_type in ("out_invoice", "out_refund")
+                for move in rec.move_ids
+            )
+
     def default_get(self, fields):
         res = super().default_get(fields)
-        if res:
-            res["count_inv"] = len(res["move_ids"][0][2])
+        move_ids = res.get("move_ids", [])
+        if move_ids and move_ids[0][0] == 6:
+            res["count_inv"] = len(move_ids[0][2])
         return res
 
     def action_background_post(self):
-        self.move_ids.filtered(lambda m: m.state == "draft").background_post = True
-        self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
+        moves = self.move_ids.filtered(
+            lambda move: move.state == "draft"
+            and move.country_code == "AR"
+            and move.move_type in ("out_invoice", "out_refund")
+        )
+        moves.background_post = True
+        if moves:
+            self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
+        return {"type": "ir.actions.act_window_close"}
 
     def validate_move(self):
-        """Sobre escribimos este método para el caso de varias invoices para hacer:
-
-        1. Que en lugar de hacer un _post hacemos un _action_post. esto porque odoo hace cosas como lanzar acciones y correr validaciones solo cuando corremos el action_post. y nosotros queremos que esas se apliquen. eso incluye el envio de email cuando validamos la factura.
-
-        2. que se valida cada factura una a uno y no todas jutnas. esto para evitar problemas que puedan surgier
-        por errores, que no se puedan ejecutar los commits que tenemos para guardar el estado de factura electronica y tambien para asegurar que tras cada fatura se envie su email, asi si hay un error posterior las facturas que fueron validadas aseguremos que hayan sido totalmente procesadas.
-
-        3. Limitamos sui el usuario quiere validar mas facturas que el batch size definido directamente
-        le pedimos que las valide en background."""
-        if self.count_inv:
-            if self.count_inv > self.batch_size:
-                raise UserError(
-                    _(
-                        "You can only validate on batches of size < %s invoices. If you need to validate"
-                        " more invoices please use the validate on background option",
-                        self.batch_size,
-                    )
-                )
-
-            for move in self.move_ids:
-                _logger.info("Validating invoice %s", move.id)
-                move.action_post()
-                move.env.cr.commit()
-
-            return {"type": "ir.actions.act_window_close"}
-        else:
+        background_moves = self.move_ids.filtered(
+            lambda move: move.country_code == "AR" and move.move_type in ("out_invoice", "out_refund")
+        )
+        if self.move_ids - background_moves:
             return super().validate_move()
+        if background_moves and len(background_moves) > self.batch_size:
+            raise UserError(
+                _(
+                    "You can only validate batches smaller than %s invoices. Use background posting for larger batches.",
+                    self.batch_size,
+                )
+            )
+        for move in background_moves:
+            _logger.info("Validating invoice %s", move.id)
+            move.action_post()
+            move.env.cr.commit()
+        return {"type": "ir.actions.act_window_close"}
 
     def validate_move_confirm(self):
-        """Bridge method called from the view's Confirm button renamed to
-        avoid name collision. It delegates to `validate_move` to keep the
-        same behaviour."""
         return self.validate_move()

--- a/account_background_post/wizards/validate_account_move_views.xml
+++ b/account_background_post/wizards/validate_account_move_views.xml
@@ -8,25 +8,26 @@
             <field name="arch" type="xml">
 
                 <field name="force_post" position="attributes">
-                    <attribute name="invisible">1</attribute>
+                    <attribute name="invisible">use_background_post</attribute>
                 </field>
 
                 <field name="force_post" position="after">
                     <field name="count_inv" invisible="1"/>
                     <field name="force_background" invisible="1"/>
+                    <field name="use_background_post" invisible="1"/>
                 </field>
 
                 <button name="validate_move" position="before">
-                    <button string="Post in Background" name="action_background_post" type="object" default_focus="1" class="btn-primary" data-hotkey="a" help="With this, all the invoices selected to be validated will be marked and they will be validated one by one. If an error is found when validating any invoice, the automatic validation of the same will be unmarked and it will be notified via messaging"
-                    invisible="abnormal_amount_partner_ids or abnormal_date_partner_ids"/>
+                    <button string="Post in Background" name="action_background_post" type="object" default_focus="1" class="btn-primary" data-hotkey="a"
+                    invisible="not use_background_post or abnormal_amount_partner_ids or abnormal_date_partner_ids"/>
                     <button string="Confirm Now" name="validate_move_confirm" type="object"
                     default_focus="1" class="btn-primary" data-hotkey="q" context="{'validate_analytic': True}"
-                    confirm="Only use this option to post a small batch of invoices" invisible="force_background"
-                    />
+                    confirm="Only use this option to post a small batch of invoices"
+                    invisible="not use_background_post or force_background"/>
                 </button>
 
                 <button name="validate_move" position="attributes">
-                    <attribute name="invisible">1</attribute>
+                    <attribute name="invisible">use_background_post</attribute>
                 </button>
 
             </field>

--- a/account_invoice_commission/__manifest__.py
+++ b/account_invoice_commission/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Commission Invoices",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.3.1",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_invoice_commission/migrations/19.0.1.3.1/post-migration.py
+++ b/account_invoice_commission/migrations/19.0.1.3.1/post-migration.py
@@ -1,0 +1,10 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    last_id = 0
+    while moves := env["account.move"].search([("id", ">", last_id)], order="id", limit=10000):
+        env.add_to_compute(moves._fields["date_last_payment"], moves)
+        moves._recompute_recordset(["date_last_payment"])
+        last_id = moves[-1].id

--- a/account_invoice_commission/models/account_move.py
+++ b/account_invoice_commission/models/account_move.py
@@ -57,13 +57,14 @@ class AccountMove(models.Model):
             users = rec.partner_id.user_ids
             rec.partner_user_id = users and users[0] or False
 
-    # dependemos de amount_residual que depende de line_ids.amount_residual porque no hay ningun campo almacenado que
-    # vaya derecho contra las lineas de pago, toda esa logica ya la tiene implementada el campo
+    # amount_residual already tracks payment reconciliation changes.
     @api.depends("amount_residual")
     def _compute_date_last_payment(self):
-        for rec in self.filtered(lambda x: x.move_type != "entry" and x.state == "posted"):
-            payments = rec._get_reconciled_payments()
-            rec.date_last_payment = payments and payments[-1].date
+        for rec in self:
+            rec.date_last_payment = False
+            if rec.move_type != "entry" and rec.state == "posted":
+                payments = rec._get_reconciled_payments()
+                rec.date_last_payment = payments and payments[-1].date
 
     @api.depends("invoice_line_ids.commission_amount")
     @api.depends_context("commissioned_partner_id")
@@ -77,31 +78,33 @@ class AccountMove(models.Model):
             self.commission_amount = 0.0
 
     def web_read(self, specification):
-        """Esto lo agregamos para propagar el contexto del commissioned_partner_id
-        La idea es que si esta presente el campo commissioned_invoice_ids agregamos en el contexto
-        el commissioned_partner_id y llamamos a super de web_read pisando estos valores."""
+        """Propagate the commissioned partner through nested reads."""
         res = super().web_read(specification)
         for vals, rec in zip(res, self):
             partner_id = vals.get("partner_id")
             if (
-                partner_id
+                rec.country_code == "AR"
+                and partner_id
                 and isinstance(partner_id, dict)
                 and partner_id.get("id")
                 and "commissioned_invoice_ids" in specification
             ):
                 vals["commissioned_invoice_ids"] = (
-                    super(AccountMove, rec)
-                    .with_context(commissioned_partner_id=vals["partner_id"]["id"])
-                    .web_read({"commissioned_invoice_ids": specification["commissioned_invoice_ids"]})[0][
+                    super(
+                        AccountMove,
+                        rec.with_context(commissioned_partner_id=vals["partner_id"]["id"]),
+                    ).web_read({"commissioned_invoice_ids": specification["commissioned_invoice_ids"]})[0][
                         "commissioned_invoice_ids"
                     ]
                 )
         return res
 
     def _fetch_duplicate_reference(self, matching_states=("draft", "posted")):
-        # Delete this when https://github.com/odoo/odoo/pull/210164 is merged
-        # Bypass the duplicate payment check for main payments
-        bypass_moves_with_commission = self.filtered(lambda x: x.commissioned_invoice_ids or x.commission_invoice_ids)
-        if bypass_moves_with_commission:
-            return {}
-        return super()._fetch_duplicate_reference(matching_states=matching_states)
+        duplicates = super()._fetch_duplicate_reference(matching_states=matching_states)
+        bypass_moves = self.filtered(
+            lambda move: move.country_code == "AR"
+            and (move.commissioned_invoice_ids or move.commission_invoice_ids)
+        )
+        for move in bypass_moves:
+            duplicates[move] = self.env["account.move"]
+        return duplicates

--- a/account_invoice_control/__manifest__.py
+++ b/account_invoice_control/__manifest__.py
@@ -20,7 +20,7 @@
 {
     "name": "Account Invoice Control",
     "author": "ADHOC SA",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "license": "AGPL-3",
     "category": "Accounting & Finance",
     "depends": ["sale", "account"],
@@ -30,4 +30,5 @@
     ],
     "website": "www.adhoc.com.ar",
     "installable": True,
+    "auto_install": False,
 }

--- a/account_invoice_control/models/account_move.py
+++ b/account_invoice_control/models/account_move.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
@@ -11,12 +11,14 @@ class AccountMove(models.Model):
     restrict_edit_invoice = fields.Boolean(compute="_compute_restrict_edit_invoice")
     has_sales = fields.Boolean(string="Has Sales?", compute="_compute_has_sales")
 
+    @api.depends_context("uid")
     def _compute_restrict_edit_invoice(self):
         if self.env.user.has_group("account_invoice_control.group_restrict_edit_invoice"):
             self.restrict_edit_invoice = True
         else:
             self.restrict_edit_invoice = False
 
+    @api.depends("invoice_line_ids.sale_line_ids")
     def _compute_has_sales(self):
         moves = self.filtered(lambda move: move.is_sale_document())
         (self - moves).has_sales = False

--- a/account_invoice_prices_update/__manifest__.py
+++ b/account_invoice_prices_update/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Invoice Prices Update",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "ADHOC SA",
     "license": "AGPL-3",
     "category": "Accounting & Finance",
@@ -31,4 +31,5 @@
         "security/ir.model.access.csv",
     ],
     "installable": True,
+    "auto_install": False,
 }

--- a/account_invoice_tax/__manifest__.py
+++ b/account_invoice_tax/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Invoice Tax",
-    "version": "19.0.1.1.2",
+    "version": "19.0.1.1.3",
     "author": "ADHOC SA",
     "category": "Localization",
     "depends": [

--- a/account_invoice_tax/models/account_move.py
+++ b/account_invoice_tax/models/account_move.py
@@ -13,30 +13,10 @@ class AccountMove(models.Model):
     tax_override_data = fields.Json()
 
     def sync_tax_override_from_tax_totals(self):
-        """Rebuild ``tax_override_data`` from the current ``tax_totals`` widget value.
-
-        Iterates every tax group in ``tax_totals`` and, for each fixed-amount
-        tax found, stores the displayed amounts as an override so they survive
-        future recomputations.
-
-        ``tax_totals`` structure (relevant fields)::
-
-            {
-                "subtotals": [{
-                    "tax_groups": [{
-                        "involved_tax_ids": [<tax_id>, ...],
-                        "tax_amount":          <float>,   # company currency
-                    }, ...]
-                }, ...]
-            }
-
-        ``amount`` (invoice-currency) → ``tax_amount_currency`` when the
-        invoice is in a foreign currency, otherwise ``tax_amount``.
-        ``amount_company_currency`` → ``tax_amount`` (always company currency),
-        or 0.0 when the invoice is in company currency (field unused in that
-        case, see ``_apply_tax_overrides``).
-        """
-        for rec in self.filtered(lambda m: m.move_type in ("in_invoice", "in_refund", "in_receipt")):
+        for rec in self.filtered(
+            lambda move: move.country_code == "AR"
+            and move.move_type in ("in_invoice", "in_refund", "in_receipt")
+        ):
             tax_totals = rec.tax_totals
             if not tax_totals:
                 continue
@@ -76,20 +56,21 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         for move in self:
             overrides = move.tax_override_data or {}
-            if not overrides:
+            if move.country_code != "AR" or not overrides:
                 super(AccountMove, move)._compute_tax_totals()
                 continue
 
             tax_context = {
                 "tax_context": {
                     int(tax_id): {
-                        "fixed_amount": (vals["amount"]),
-                        "rate": (move.invoice_currency_rate or 1.0),
+                        "fixed_amount": vals["amount"],
+                        "rate": move.invoice_currency_rate or 1.0,
                     }
                     for tax_id, vals in overrides.items()
                 },
             }
             super(AccountMove, move.with_context(**tax_context))._compute_tax_totals()
+            move.tax_totals["account_invoice_tax_readonly"] = True
 
     # ------------------------------------------------------------------
     # Re-apply overrides after every tax-line recomputation so that the
@@ -99,23 +80,12 @@ class AccountMove(models.Model):
 
     @contextmanager
     def _sync_tax_lines(self, container):
-        """Restore manually-set tax amounts after the core recomputes tax lines.
+        records = container.get("records", self).filtered(lambda move: move.country_code == "AR")
+        if not records:
+            with super()._sync_tax_lines(container):
+                yield
+            return
 
-        Also fixes a core Odoo ordering issue: within ``_sync_dynamic_lines``
-        the ``ExitStack`` unwinds in LIFO order, so ``line._sync_invoice``
-        exits *before* ``_sync_tax_lines``.  When the invoice date changes on
-        a foreign-currency invoice, ``line._sync_invoice`` rewrites the
-        ``balance`` of every line (including tax lines) for the new exchange
-        rate.  ``_sync_tax_lines`` then sees those touched balances and
-        concludes that the tax amounts were manually edited
-        (``round_from_tax_lines = True``), so it preserves the old totals
-        even though a base line was deleted at the same time.
-
-        We detect that scenario here and force a full recompute from base
-        lines so that the amounts correctly reflect only the remaining lines.
-        """
-        # Capture state before the main yield so we can detect the scenario.
-        records = container.get("records", self)
         _before_state = {
             move: {
                 "rate": move.invoice_currency_rate,
@@ -131,10 +101,7 @@ class AccountMove(models.Model):
             yield
 
         AccountTax = self.env["account.tax"]
-        for move in container.get("records", self):
-            # Fix: when the invoice currency rate changed at the same time as a
-            # taxed base line was deleted, the core may have preserved the stale
-            # tax totals.  Re-run the computation from base lines in that case.
+        for move in records:
             if move.state == "draft" and move.id:
                 before = _before_state.get(move)
                 if before and before["rate"] != move.invoice_currency_rate:

--- a/account_invoice_tax/models/account_tax.py
+++ b/account_invoice_tax/models/account_tax.py
@@ -7,9 +7,8 @@ class AccountTax(models.Model):
     @api.model
     def _get_tax_totals_summary(self, base_lines, currency, company, cash_rounding=None):
         res = super()._get_tax_totals_summary(base_lines, currency, company, cash_rounding=cash_rounding)
-        # ``tax_context`` is injected by AccountMove._compute_tax_totals when
-        # there are active tax overrides.  Structure:
-        #   { tax_id (int): {'fixed_amount': float, 'rate': float}, ... }
+        if company.account_fiscal_country_id.code != "AR":
+            return res
         if tax_context := self.env.context.get("tax_context"):
             original_amount_by_tax_id = {}
             original_amount_currency_by_tax_id = {}

--- a/account_invoice_tax/static/src/xml/tax_totals.xml
+++ b/account_invoice_tax/static/src/xml/tax_totals.xml
@@ -2,12 +2,14 @@
 <templates>
 
     <t t-name="account.TaxGroupComponent" t-inherit="account.TaxGroupComponent" t-inherit-mode="extension" owl="1">
-        <xpath expr="//span[hasclass('o_tax_group_edit')]" position="replace">
-                        <span class="o_tax_group_edit">
-                            <span class="o_tax_group_amount_value o_list_monetary">
-                            <t t-out="formatMonetary(props.taxGroup.tax_amount_currency)"/>
-                            </span>
-                        </span>
+        <xpath expr="//span[hasclass('o_tax_group_edit')]" position="attributes">
+            <attribute name="t-if">!props.isReadonly &amp;&amp; !props.totals.account_invoice_tax_readonly</attribute>
+        </xpath>
+        <xpath expr="//span[hasclass('o_tax_group_edit')]" position="after">
+            <span t-if="props.totals.account_invoice_tax_readonly"
+                  class="o_tax_group_amount_value o_list_monetary">
+                <t t-out="formatMonetary(props.taxGroup.tax_amount_currency)"/>
+            </span>
         </xpath>
     </t>
 </templates>

--- a/account_invoice_tax/views/account_move_view.xml
+++ b/account_invoice_tax/views/account_move_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="tax_totals" position="after">
 
-                <div colspan="2" class="oe_right oe_edit_only" invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund', 'in_receipt')">
+                <div colspan="2" class="oe_right oe_edit_only" invisible="country_code != 'AR' or state != 'draft' or move_type not in ('in_invoice', 'in_refund', 'in_receipt')">
                     <strong>TAX: </strong>
                     <button name="%(account_invoice_tax.action_view_account_invoice_tax)d" type="action" string="Add/update" title="Add/update fixed Tax" class="oe_link" context="{'move_type': move_type}"/>
                 </div>

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import Command, api, fields, models
+from odoo import _, Command, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -19,6 +19,8 @@ class AccountInvoiceTax(models.TransientModel):
             else self.env["account.move"]
         )
         res["move_id"] = move_ids[0].id if move_ids else False
+        if move_ids and move_ids[0].country_code != "AR":
+            raise UserError(_("This wizard is only available for Argentine companies."))
         if move_ids[0].move_type == "in_invoice":
             sign = 1
         elif move_ids[0].move_type == "in_refund":
@@ -35,8 +37,10 @@ class AccountInvoiceTax(models.TransientModel):
         return res
 
     def action_update_tax(self):
-        self.tax_line_ids.filtered(lambda l: not l.amount).unlink()
         move = self.move_id
+        if move.country_code != "AR":
+            raise UserError(_("This wizard is only available for Argentine companies."))
+        self.tax_line_ids.filtered(lambda l: not l.amount).unlink()
 
         active_tax = self.tax_line_ids.mapped("tax_id")
         origin_tax = self.move_id.line_ids.filtered(lambda x: x.tax_line_id).mapped("tax_repartition_line_id.tax_id")

--- a/website_sale_account_invoice_commission/__manifest__.py
+++ b/website_sale_account_invoice_commission/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Commission Invoices with Public Categories",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -36,6 +36,6 @@
     ],
     "demo": [],
     "installable": True,
-    "auto_install": True,
+    "auto_install": False,
     "application": False,
 }


### PR DESCRIPTION
## Summary

- Restrict Argentine background posting, tax overrides, and commission-specific core overrides to AR companies.
- Preserve standard Odoo behavior for non-Argentine companies.
- Replace the destructive tax totals OWL override with a non-destructive extension.
- Disable implicit installation for localization glue modules.
- Add a batched migration to recompute the stored commission payment-date field.
- Avoid a manual transaction commit in the invoice validation wizard.

## Validation

- `python_compileall`
- XML parsing
- Git diff whitespace and conflict checks

No Odoo module installation or functional regression testing was run because no Odoo database is configured.